### PR TITLE
use correct framework

### DIFF
--- a/JetBrains.AppStore.NotaryApi.ConsoleClient/JetBrains.AppStore.NotaryApi.ConsoleClient.csproj
+++ b/JetBrains.AppStore.NotaryApi.ConsoleClient/JetBrains.AppStore.NotaryApi.ConsoleClient.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net80</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <LangVersion>latest</LangVersion>
         <RootNamespace>ConsoleClient</RootNamespace>
         <RollForward>Major</RollForward>


### PR DESCRIPTION
the undocumented names (without period in dotnet 5+) can drop their support when move to double-digit (to avoid potential conflicts) [learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks](https://learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks)